### PR TITLE
Request body for put, patch, post

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -81,7 +81,7 @@ const api = (providedOptions = {}) => {
       options.getAuthToken
     );
     const requestConfig = {
-      baseUrl: options.baseUrl,
+      baseURL: options.baseUrl,
       params,
       data,
       headers: {
@@ -103,7 +103,9 @@ const api = (providedOptions = {}) => {
       }];
     }
 
-    return axios[method](path, requestConfig);
+    const axiosInstance = axios.create(requestConfig);
+
+    return axiosInstance[method](path);
   };
 
   return {

--- a/src/api.js
+++ b/src/api.js
@@ -104,7 +104,11 @@ const api = (providedOptions = {}) => {
       }];
     }
 
-    return axiosInstance[method](path, requestConfig);
+    if (method === 'get' || method === 'delete') {
+      return axiosInstance[method](path, requestConfig);
+    }
+
+    return axiosInstance[method](path, data, requestConfig);
   };
 
   return {

--- a/src/api.js
+++ b/src/api.js
@@ -52,6 +52,8 @@ const api = (providedOptions = {}) => {
   validateAuthOptions(providedOptions);
 
   const options = setupOptions(providedOptions);
+  
+  const axiosInstance = axios.create({ baseURL: options.baseUrl });
 
   const get = (path, params) => request('get', path, params);
 
@@ -81,7 +83,6 @@ const api = (providedOptions = {}) => {
       options.getAuthToken
     );
     const requestConfig = {
-      baseURL: options.baseUrl,
       params,
       data,
       headers: {
@@ -103,9 +104,7 @@ const api = (providedOptions = {}) => {
       }];
     }
 
-    const axiosInstance = axios.create(requestConfig);
-
-    return axiosInstance[method](path);
+    return axiosInstance[method](path, requestConfig);
   };
 
   return {

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -87,7 +87,16 @@ describe('api', () => {
       const result = await testApi.get('/path1');
 
       expect(result).toStrictEqual(response);
-      expect(axios.get).toHaveBeenLastCalledWith('/path1');
+      expect(axios.get).toHaveBeenLastCalledWith(
+        '/path1',
+        {
+          data: undefined,
+          headers: {
+            'Content-type': 'application/json; charset=utf-8',
+            'auth': 'token',
+          },
+        }
+      );
     });
 
     it('throws then the api responds with an error', async () => {
@@ -103,7 +112,16 @@ describe('api', () => {
       const result = await testApi.post('/path2', { a: 'b' });
 
       expect(result).toStrictEqual(response);
-      expect(axios.post).toHaveBeenLastCalledWith('/path2');
+      expect(axios.post).toHaveBeenLastCalledWith(
+        '/path2',
+        {
+          data: { a: 'b' },
+          headers: {
+            'Content-type': 'application/json; charset=utf-8',
+            'auth': 'token',
+          },
+        }
+      );
     });
 
     it('makes JSON POST requests without data', async () => {
@@ -113,7 +131,16 @@ describe('api', () => {
       const result = await testApi.post('/path3');
 
       expect(result).toStrictEqual(response);
-      expect(axios.post).toHaveBeenLastCalledWith('/path3');
+      expect(axios.post).toHaveBeenLastCalledWith(
+        '/path3',
+        {
+          data: {},
+          headers: {
+            'Content-type': 'application/json; charset=utf-8',
+            'auth': 'token',
+          },
+        }
+      );
     });
 
     it('makes PUT requests', async () => {
@@ -123,7 +150,16 @@ describe('api', () => {
       const result = await testApi.put('/path4', { a: 'c' });
 
       expect(result).toStrictEqual(response);
-      expect(axios.put).toHaveBeenLastCalledWith('/path4');
+      expect(axios.put).toHaveBeenLastCalledWith(
+        '/path4',
+        {
+          data: { a: 'c' },
+          headers: {
+            'Content-type': 'application/json; charset=utf-8',
+            'auth': 'token',
+          },
+        }
+      );
     });
 
     it('makes PATCH requests', async () => {
@@ -133,7 +169,16 @@ describe('api', () => {
       const result = await testApi.patch('/path5', { b: 'c' });
 
       expect(result).toStrictEqual(response);
-      expect(axios.patch).toHaveBeenLastCalledWith('/path5');
+      expect(axios.patch).toHaveBeenLastCalledWith(
+        '/path5',
+        {
+          data: { b: 'c' },
+          headers: {
+            'Content-type': 'application/json; charset=utf-8',
+            'auth': 'token',
+          },
+        }
+      );
     });
 
     it('makes DELETE requests', async () => {
@@ -143,7 +188,16 @@ describe('api', () => {
       const result = await testApi.remove('/path6');
 
       expect(result).toStrictEqual(response);
-      expect(axios.delete).toHaveBeenLastCalledWith('/path6');
+      expect(axios.delete).toHaveBeenLastCalledWith(
+        '/path6',
+        {
+          data: undefined,
+          headers: {
+            'Content-type': 'application/json; charset=utf-8',
+            'auth': 'token',
+          },
+        }
+      );
     });
 
     it('makes form data requests', async () => {
@@ -153,26 +207,26 @@ describe('api', () => {
       const result = await testApi
         .post('/path7', { f: 'd' }, undefined, contentTypes.FORM_DATA);
 
-      const lastCall = axios.create.mock.calls[axios.create.mock.calls.length - 1];
+      const lastCall = axios.post.mock.calls[axios.post.mock.calls.length - 1];
 
       expect(result).toStrictEqual(response);
-      expect(typeof lastCall[0].transformRequest[0]).toBe('function');
-      expect(lastCall[0].headers).toStrictEqual(
+      expect(typeof lastCall[1].transformRequest[0]).toBe('function');
+      expect(lastCall[1].headers).toStrictEqual(
         {
           'Content-type': 'multipart/form-data',
           'auth': 'token',
         },
       );
 
-      const formData = lastCall[0].transformRequest[0]({ f: 'd' });
+      const formData = lastCall[1].transformRequest[0]({ f: 'd' });
       expect(formData instanceof FormData).toBe(true);
       expect(formData.get('f')).toBe('d');
 
       expect(() => {
-        lastCall[0].transformRequest[0](null)
+        lastCall[1].transformRequest[0](null)
       }).toThrow();
       expect(() => {
-        lastCall[0].transformRequest[0](123)
+        lastCall[1].transformRequest[0](123)
       }).toThrow();
     });
 
@@ -192,7 +246,15 @@ describe('api', () => {
       const result = await api({ baseUrl: 'http://localhost:3000' }).get('/ok');
 
       expect(result).toStrictEqual(response);
-      expect(axios.get).toHaveBeenLastCalledWith('/ok');
+      expect(axios.get).toHaveBeenLastCalledWith(
+        '/ok',
+        {
+          data: undefined,
+          headers: {
+            'Content-type': 'application/json; charset=utf-8',
+          },
+        }
+      );
     });
   });
 });

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -114,6 +114,7 @@ describe('api', () => {
       expect(result).toStrictEqual(response);
       expect(axios.post).toHaveBeenLastCalledWith(
         '/path2',
+        { a: 'b' },
         {
           data: { a: 'b' },
           headers: {
@@ -133,6 +134,7 @@ describe('api', () => {
       expect(result).toStrictEqual(response);
       expect(axios.post).toHaveBeenLastCalledWith(
         '/path3',
+        {},
         {
           data: {},
           headers: {
@@ -152,6 +154,7 @@ describe('api', () => {
       expect(result).toStrictEqual(response);
       expect(axios.put).toHaveBeenLastCalledWith(
         '/path4',
+        { a: 'c' },
         {
           data: { a: 'c' },
           headers: {
@@ -171,6 +174,7 @@ describe('api', () => {
       expect(result).toStrictEqual(response);
       expect(axios.patch).toHaveBeenLastCalledWith(
         '/path5',
+        { b: 'c' },
         {
           data: { b: 'c' },
           headers: {
@@ -210,23 +214,23 @@ describe('api', () => {
       const lastCall = axios.post.mock.calls[axios.post.mock.calls.length - 1];
 
       expect(result).toStrictEqual(response);
-      expect(typeof lastCall[1].transformRequest[0]).toBe('function');
-      expect(lastCall[1].headers).toStrictEqual(
+      expect(typeof lastCall[2].transformRequest[0]).toBe('function');
+      expect(lastCall[2].headers).toStrictEqual(
         {
           'Content-type': 'multipart/form-data',
           'auth': 'token',
         },
       );
 
-      const formData = lastCall[1].transformRequest[0]({ f: 'd' });
+      const formData = lastCall[2].transformRequest[0]({ f: 'd' });
       expect(formData instanceof FormData).toBe(true);
       expect(formData.get('f')).toBe('d');
 
       expect(() => {
-        lastCall[1].transformRequest[0](null)
+        lastCall[2].transformRequest[0](null)
       }).toThrow();
       expect(() => {
-        lastCall[1].transformRequest[0](123)
+        lastCall[2].transformRequest[0](123)
       }).toThrow();
     });
 

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -71,6 +71,8 @@ describe('api', () => {
     let testApi;
 
     beforeAll(() => {
+      axios.create.mockReturnThis();
+
       testApi = api({
         baseUrl: 'http://localhost:3000',
         tokenHeader: 'auth',
@@ -85,17 +87,7 @@ describe('api', () => {
       const result = await testApi.get('/path1');
 
       expect(result).toStrictEqual(response);
-      expect(axios.get).toHaveBeenLastCalledWith(
-        '/path1',
-        {
-          baseUrl: 'http://localhost:3000',
-          data: undefined,
-          headers: {
-            'Content-type': 'application/json; charset=utf-8',
-            'auth': 'token',
-          },
-        }
-      );
+      expect(axios.get).toHaveBeenLastCalledWith('/path1');
     });
 
     it('throws then the api responds with an error', async () => {
@@ -111,17 +103,7 @@ describe('api', () => {
       const result = await testApi.post('/path2', { a: 'b' });
 
       expect(result).toStrictEqual(response);
-      expect(axios.post).toHaveBeenLastCalledWith(
-        '/path2',
-        {
-          baseUrl: 'http://localhost:3000',
-          data: { a: 'b' },
-          headers: {
-            'Content-type': 'application/json; charset=utf-8',
-            'auth': 'token',
-          },
-        }
-      );
+      expect(axios.post).toHaveBeenLastCalledWith('/path2');
     });
 
     it('makes JSON POST requests without data', async () => {
@@ -131,17 +113,7 @@ describe('api', () => {
       const result = await testApi.post('/path3');
 
       expect(result).toStrictEqual(response);
-      expect(axios.post).toHaveBeenLastCalledWith(
-        '/path3',
-        {
-          baseUrl: 'http://localhost:3000',
-          data: {},
-          headers: {
-            'Content-type': 'application/json; charset=utf-8',
-            'auth': 'token',
-          },
-        }
-      );
+      expect(axios.post).toHaveBeenLastCalledWith('/path3');
     });
 
     it('makes PUT requests', async () => {
@@ -151,17 +123,7 @@ describe('api', () => {
       const result = await testApi.put('/path4', { a: 'c' });
 
       expect(result).toStrictEqual(response);
-      expect(axios.put).toHaveBeenLastCalledWith(
-        '/path4',
-        {
-          baseUrl: 'http://localhost:3000',
-          data: { a: 'c' },
-          headers: {
-            'Content-type': 'application/json; charset=utf-8',
-            'auth': 'token',
-          },
-        }
-      );
+      expect(axios.put).toHaveBeenLastCalledWith('/path4');
     });
 
     it('makes PATCH requests', async () => {
@@ -171,17 +133,7 @@ describe('api', () => {
       const result = await testApi.patch('/path5', { b: 'c' });
 
       expect(result).toStrictEqual(response);
-      expect(axios.patch).toHaveBeenLastCalledWith(
-        '/path5',
-        {
-          baseUrl: 'http://localhost:3000',
-          data: { b: 'c' },
-          headers: {
-            'Content-type': 'application/json; charset=utf-8',
-            'auth': 'token',
-          },
-        }
-      );
+      expect(axios.patch).toHaveBeenLastCalledWith('/path5');
     });
 
     it('makes DELETE requests', async () => {
@@ -191,17 +143,7 @@ describe('api', () => {
       const result = await testApi.remove('/path6');
 
       expect(result).toStrictEqual(response);
-      expect(axios.delete).toHaveBeenLastCalledWith(
-        '/path6',
-        {
-          baseUrl: 'http://localhost:3000',
-          data: undefined,
-          headers: {
-            'Content-type': 'application/json; charset=utf-8',
-            'auth': 'token',
-          },
-        }
-      );
+      expect(axios.delete).toHaveBeenLastCalledWith('/path6');
     });
 
     it('makes form data requests', async () => {
@@ -211,26 +153,26 @@ describe('api', () => {
       const result = await testApi
         .post('/path7', { f: 'd' }, undefined, contentTypes.FORM_DATA);
 
-      const lastCall = axios.post.mock.calls[axios.post.mock.calls.length - 1];
+      const lastCall = axios.create.mock.calls[axios.create.mock.calls.length - 1];
 
       expect(result).toStrictEqual(response);
-      expect(typeof lastCall[1].transformRequest[0]).toBe('function');
-      expect(lastCall[1].headers).toStrictEqual(
+      expect(typeof lastCall[0].transformRequest[0]).toBe('function');
+      expect(lastCall[0].headers).toStrictEqual(
         {
           'Content-type': 'multipart/form-data',
           'auth': 'token',
         },
       );
 
-      const formData = lastCall[1].transformRequest[0]({ f: 'd' });
+      const formData = lastCall[0].transformRequest[0]({ f: 'd' });
       expect(formData instanceof FormData).toBe(true);
       expect(formData.get('f')).toBe('d');
 
       expect(() => {
-        lastCall[1].transformRequest[0](null)
+        lastCall[0].transformRequest[0](null)
       }).toThrow();
       expect(() => {
-        lastCall[1].transformRequest[0](123)
+        lastCall[0].transformRequest[0](123)
       }).toThrow();
     });
 
@@ -244,21 +186,13 @@ describe('api', () => {
 
     it('makes requests when the auth token is not defined', async () => {
       const response = { ok: true };
+
       axios.get.mockResolvedValue(response);
 
       const result = await api({ baseUrl: 'http://localhost:3000' }).get('/ok');
 
       expect(result).toStrictEqual(response);
-      expect(axios.get).toHaveBeenLastCalledWith(
-        '/ok',
-        {
-          baseUrl: 'http://localhost:3000',
-          data: undefined,
-          headers: {
-            'Content-type': 'application/json; charset=utf-8',
-          },
-        }
-      );
+      expect(axios.get).toHaveBeenLastCalledWith('/ok');
     });
   });
 });


### PR DESCRIPTION
Send request body as the 2nd parameter in case of put, patch, post requests
Send options (config) as 2nd parameter in case of get and delete requests

